### PR TITLE
Optional MySql Refresh TTL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const mysql = require('mysql2');
+const cachify = require('./lib/cachify-pool');
 
 const pingDb = async(pool) => {
   return new Promise((resolve, reject) => {
@@ -15,6 +16,10 @@ const pingDb = async(pool) => {
 
 module.exports = function(mysqlConfig, logger) {
   const pool = mysql.createPool(mysqlConfig);
+
+  if (process.env.JAMBONES_MYSQL_REFRESH_TTL)
+    cachify(pool);
+
   logger = logger || {info: () => {}, error: () => {}, debug: () => {}};
   pool.getConnection((err, conn) => {
     if (err) throw err;

--- a/lib/cachify-pool.js
+++ b/lib/cachify-pool.js
@@ -1,0 +1,40 @@
+const debug = require('debug')('jambonz:db-helpers');
+const hasher = require('node-object-hash');
+const hashSha1 = hasher({alg: 'sha1'});
+
+const cache = {};
+
+function augment(pp, fnName) {
+  const refresh = pp[fnName];
+  pp[fnName] = async function() {
+    const sha1 = hashSha1.hash(arguments);
+    let val = cache[sha1];
+    if (!val) {
+      val = await refresh.apply(pp, arguments);
+      cache[sha1] = val;
+      setTimeout(function() {
+        delete cache[sha1];
+      }, parseInt(process.env.JAMBONES_MYSQL_REFRESH_TTL, 10) * 1000);
+
+      debug(`cache: ${sha1}`, arguments);
+    }
+    return val;
+  };
+}
+
+/**
+ * Cache the results of all SELECT queries
+ * @param {*} pool
+ */
+function cachify(pool) {
+  const cachePromise = pool.promise;
+  pool.promise = function() {
+    const pp = cachePromise.apply(pool, arguments);
+    ['execute', 'query'].forEach(function(fnName) {
+      augment(pp, fnName);
+    });
+    return pp;
+  };
+}
+
+module.exports = cachify;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cidr-matcher": "^2.1.1",
         "debug": "^4.3.3",
         "mysql2": "^2.3.3",
+        "node-object-hash": "^2.3.10",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -20,6 +21,7 @@
         "eslint-plugin-promise": "^5.1.0",
         "husky": "^7.0.0",
         "nyc": "^15.1.0",
+        "sinon": "^14.0.0",
         "tape": "^5.2.2"
       }
     },
@@ -464,6 +466,41 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -927,6 +964,15 @@
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -1974,6 +2020,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2179,6 +2231,12 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2226,6 +2284,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -2351,6 +2415,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/node-object-hash": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-2.3.10.tgz",
+      "integrity": "sha512-jY5dPJzw6NHd/KPSfPKJ+IHoFS81/tJ43r34ZeNMXGzCOM8jwQDCD12HYayKIB6MuznrnqIYy2e891NA2g0ibA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -2606,6 +2691,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -2849,6 +2943,24 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
@@ -3124,6 +3236,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -3758,6 +3879,41 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -4114,6 +4270,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
       "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+    },
+    "diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true
     },
     "doctrine": {
       "version": "3.0.0",
@@ -4871,6 +5033,12 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5034,6 +5202,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5075,6 +5249,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -5183,6 +5363,24 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node-object-hash": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-2.3.10.tgz",
+      "integrity": "sha512-jY5dPJzw6NHd/KPSfPKJ+IHoFS81/tJ43r34ZeNMXGzCOM8jwQDCD12HYayKIB6MuznrnqIYy2e891NA2g0ibA=="
     },
     "node-preload": {
       "version": "0.2.1",
@@ -5377,6 +5575,15 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -5557,6 +5764,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      }
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -5771,6 +5992,12 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,16 @@
     "cidr-matcher": "^2.1.1",
     "debug": "^4.3.3",
     "mysql2": "^2.3.3",
+    "node-object-hash": "^2.3.10",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "config": "^3.3.6",
     "eslint": "^7.27.0",
     "eslint-plugin-promise": "^5.1.0",
+    "husky": "^7.0.0",
     "nyc": "^15.1.0",
-    "tape": "^5.2.2",
-    "husky": "^7.0.0"
+    "sinon": "^14.0.0",
+    "tape": "^5.2.2"
   }
 }

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,107 @@
+const test = require('tape').test;
+const sinon = require('sinon');
+const config = require('config');
+const cachify = require('../lib/cachify-pool');
+const mysqlOpts = config.get('mysql');
+
+process.on('unhandledRejection', (reason, p) => {
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+});
+
+let clock;
+
+test('cache tests', async(t) => {
+  clock = sinon.useFakeTimers();
+
+  t.teardown(function () {
+    delete process.env.JAMBONES_MYSQL_REFRESH_TTL;
+    clock.restore();
+  });
+
+  const fn = require('..');
+  const {pool, lookupCarrierBySid, lookupAppByPhoneNumber} = fn(mysqlOpts);
+
+  const spies = {
+    execute: sinon.spy(),
+    query: sinon.spy()
+  }
+
+  const testPromise = pool.promise;
+  pool.promise = function () {
+    const pp = testPromise.apply(pool, arguments);
+    ['execute', 'query'].forEach(function (fnName) {
+      const fn = pp[fnName];
+      pp[fnName] = async function () {
+        spies[fnName]();
+        return await fn.apply(pp, arguments);
+      };
+
+    });
+    return pp;
+  }
+
+  process.env.JAMBONES_MYSQL_REFRESH_TTL = '30';
+  cachify(pool);
+
+  let executeFixture;
+  let queryFixture;
+  let allCachedMatchOriginal = true;
+
+  async function execute1000() {
+    for (let i = 0; i < 1000; i++) {
+      const pp = pool.promise();
+      const [r] = await pp.execute(`SELECT * FROM voip_carriers WHERE voip_carrier_sid = ?`, ['287c1452-620d-4195-9f19-c9814ef90d78']);
+
+      if (!executeFixture) {
+        executeFixture = JSON.stringify(r[0]);
+      }
+      else if (JSON.stringify(r[0]) !== executeFixture) {
+        allCachedMatchOriginal = false;
+      }
+    }
+  }
+
+  async function query1000() {
+    for (let i = 0; i < 1000; i++) {
+      const pp = pool.promise();
+      const [r] = await pp.query('SELECT application_sid from voip_carriers where voip_carrier_sid = ?', '3b43e39f-4346-4218-8434-a53130e8be49');
+
+      if (!queryFixture) {
+        queryFixture = JSON.stringify(r[0]);
+      }
+      else if (JSON.stringify(r[0]) !== queryFixture) {
+        allCachedMatchOriginal = false;
+      }
+    }
+  }
+
+  try {
+    await execute1000();
+    await query1000();
+
+    t.ok(spies.execute.calledOnce && spies.query.calledOnce, 'calls database only 1 / 1000');
+
+    clock.tick(25000);
+
+    await execute1000();
+    await query1000();
+
+    t.ok(spies.execute.calledOnce && spies.query.calledOnce, 'remains in cache after 25sec');
+
+    clock.tick(5000);
+
+    await execute1000();
+    await query1000();
+
+    t.ok(spies.execute.calledTwice && spies.query.calledTwice, 'refreshes from db and caches again after 30sec');
+    t.ok(allCachedMatchOriginal, 'all cached results match db originals');
+
+    t.end();
+  }
+  catch (err) {
+    t.end(err);
+  }
+
+  delete process.env.JAMBONES_MYSQL_REFRESH_TTL;
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ require('./teams');
 require('./lookup-auth');
 require('./sip-gateways');
 require('./app');
+require('./cache');
 require('./lcr');
 require('./add-sbc-address');
 require('./docker_stop');


### PR DESCRIPTION
An elegant modification to optionally cache every unique SQL query resultset in memory for a defined period specified by the `JAMBONES_MYSQL_REFRESH_TTL` environment variable.

If set, the `JAMBONES_MYSQL_REFRESH_TTL` denotes the time in seconds to discard each cached result after it has been refreshed from the database.

The modification is activated by overriding each MySql `pool promise` `execute` and `query` methods.

Tests also provided, @davehorton kindly advise if this is useful / appropriate in the current form, and if so please advise if you wish anything to be changed, including syntax and nomenclature.