### PR TITLE
Select only service provider carriers with no owning account

### DIFF
--- a/lib/perform-lcr.js
+++ b/lib/perform-lcr.js
@@ -19,7 +19,8 @@ vc.register_password, vc.tech_prefix, vc.diversion, vc.account_sid, vc.service_p
 FROM sip_gateways sg, voip_carriers vc
 WHERE sg.is_active = 1
 AND sg.voip_carrier_sid = vc.voip_carrier_sid
-AND vc.is_active = 1 
+AND vc.is_active = 1
+AND vc.account_sid IS NULL 
 AND vc.service_provider_sid = (SELECT service_provider_sid FROM accounts WHERE account_sid = ?)  
 AND sg.outbound = 1`;
 


### PR DESCRIPTION
Hi Dave,

You're welcome to ignore this pull request if the current behaviour was intended.

While investigating a problem with retrying of outbound carriers when the caller had hung up (which you've fixed already). I noticed it was selecting all outbound gateways within the service provider, account_sid set or not. I modified the query slightly so it only selects "global" carriers.

Cheers,

Matt