### PR TITLE
lookupAccountSettingsBySid should not return pending subscriptions be…

### DIFF
--- a/lib/lookup-account-capacities-by-sid.js
+++ b/lib/lookup-account-capacities-by-sid.js
@@ -4,6 +4,7 @@ const sql =
 `select prod.category, ap.quantity
  from products prod, account_products ap, account_subscriptions subs
  where subs.account_sid = ?
+ and subs.pending = 0
  AND (subs.effective_end_date IS NULL OR subs.effective_end_date > NOW() )
  and ap.account_subscription_sid = subs.account_subscription_sid
  and ap.product_sid = prod.product_sid`;


### PR DESCRIPTION
…cause these are subscriptions that have failed due to payment failure